### PR TITLE
Support notifications for SD cards.

### DIFF
--- a/config.h
+++ b/config.h
@@ -1,2 +1,2 @@
 #define SOCK_PATH "/var/run/devd.pipe"
-#define REGEX "subsystem=CDEV type=(CREATE|DESTROY) cdev=(da[0-9]+[a-z]+[0-9]?[a-z]?)"
+#define REGEX "subsystem=CDEV type=(CREATE|DESTROY) cdev=((da|mmcsd)[0-9]+[a-z]+[0-9]?[a-z]?)"


### PR DESCRIPTION
Tweak the regular expression a bit.
SD cards are using device nodes such as mmcsd0s1, so no notification would appear when we were looking for da0s1 device nodes.
